### PR TITLE
Use xonsh to call 'real' conda, not subprocess

### DIFF
--- a/xontrib/xonda.xsh
+++ b/xontrib/xonda.xsh
@@ -93,8 +93,7 @@ def _xonda(args, stdin=None):
     elif len(args) == 1 and args[0] is 'deactivate':
         _deactivate()
     elif len(args) > 0:
-        subprocess.call(['conda'] + args,
-                                env=__xonsh_env__.detype())
+        @$(which -s conda) @(args)
     else:
         return
 


### PR DESCRIPTION
Swapping in the `@$` operator to force resolution of the actual `conda`
entry point means that `subprocess` doesn't swallow `stdout` and
`stderr`. And given that this is already a `xsh`-based xontrib, it seems
reasonable that it would use xonsh syntax for this.

Should address #11 

@scopatz, @asmeurer -- if either of you can try this out and confirm that it fixes your issue that would be great.  Thanks!