### PR TITLE
Remove $SHELL from `symlink_conda` call

### DIFF
--- a/xontrib/xonda.xsh
+++ b/xontrib/xonda.xsh
@@ -65,9 +65,7 @@ def _activate(env_name):
         if env.bin_dir not in $PATH:
             $PATH.insert(0, env.bin_dir)
         # ensure conda symlink exists in directory
-        ci.symlink_conda(env.path,
-                                    config.default_prefix,
-                                    $SHELL)
+        ci.symlink_conda(env.path, config.default_prefix)
     else:
         print("No environment '{}' found".format(env_name))
 


### PR DESCRIPTION
`$SHELL` should return the users default shell, which might not be `xonsh`, so
this shouldn't be in there anyway.
In any case, it seems like the `shell=` kwarg is only used on Windows and even
there I don't know if it's required.

If it turns out to be an issue for windows users, I'm sure they'll let me know.